### PR TITLE
ci: configure semantic release in GitHub Action

### DIFF
--- a/.github/workflows/sematic-release.yml
+++ b/.github/workflows/sematic-release.yml
@@ -1,0 +1,41 @@
+name: sematic-release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: release
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Setup | Force correct release branch on workflow sha
+        run: |
+          git checkout -B ${{ github.ref_name }} ${{ github.sha }}
+      - name: Update Semantic Version Release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v9.16.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_committer_name: 'github-actions'
+          git_committer_email: 'actions@users.noreply.github.com'
+          changelog: 'false'
+
+      - name: Upload to GitHub Release Assets
+        uses: python-semantic-release/publish-action@v9.16.1
+        if: steps.release.outputs.released == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
implement #31 
I use [python-sematic-release](https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html)